### PR TITLE
Improve portfolio design

### DIFF
--- a/src/components/layout/Footer.js
+++ b/src/components/layout/Footer.js
@@ -15,7 +15,7 @@ const Footer = () => {
     }, []); // El array de dependencias está vacío, por lo que el efecto se ejecuta solo una vez al montar el componente
 
     return (
-        <div className="bg-gray-800 text-white py-4 px-6">
+        <div className="bg-gradient-to-r from-gray-900 via-blue-900 to-blue-800 text-white py-4 px-6 mt-8">
             <h1 className="text-2xl mb-4">{t("footer")}</h1>
             <p className="mb-4">La página ha sido visitada {visitCount} veces.</p>
             <div>

--- a/src/components/layout/HeaderNav.js
+++ b/src/components/layout/HeaderNav.js
@@ -22,7 +22,7 @@ const HeaderNav = () => {
     }, []); // Este efecto se ejecuta solo una vez al montar el componente
 
     return (
-        <div className="bg-gray-800 text-white py-4 px-6">
+        <div className="bg-gradient-to-r from-blue-800 via-blue-900 to-gray-900 text-white py-4 px-6 shadow-md">
             <h1 className="text-2xl mb-4">{t("titleHeader")}</h1>
             <div className="flex items-center">
                 <label htmlFor="languageSelect" className="mr-4">Select language:</label>

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -44,7 +44,7 @@ html,
   /* 3 */
   tab-size: 4;
   /* 3 */
-  font-family: ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  font-family: Segoe UI, Helvetica, Arial, sans-serif;
   /* 4 */
   font-feature-settings: normal;
   /* 5 */
@@ -579,21 +579,57 @@ video {
   }
 }
 
-.absolute {
-  position: absolute;
-}
-
 .mx-auto {
   margin-left: auto;
   margin-right: auto;
+}
+
+.mb-4 {
+  margin-bottom: 1rem;
 }
 
 .mb-6 {
   margin-bottom: 1.5rem;
 }
 
-.inline {
-  display: inline;
+.mb-8 {
+  margin-bottom: 2rem;
+}
+
+.mr-2 {
+  margin-right: 0.5rem;
+}
+
+.mr-4 {
+  margin-right: 1rem;
+}
+
+.mt-1 {
+  margin-top: 0.25rem;
+}
+
+.mt-2 {
+  margin-top: 0.5rem;
+}
+
+.mt-4 {
+  margin-top: 1rem;
+}
+
+.mt-6 {
+  margin-top: 1.5rem;
+}
+
+.mt-8 {
+  margin-top: 2rem;
+}
+
+.block {
+  display: block;
+}
+
+.inline-block {
+  display: inline-block;
 }
 
 .flex {
@@ -604,8 +640,144 @@ video {
   display: table;
 }
 
+.h-32 {
+  height: 8rem;
+}
+
+.h-auto {
+  height: auto;
+}
+
+.w-1\/3 {
+  width: 33.333333%;
+}
+
+.w-32 {
+  width: 8rem;
+}
+
+.w-4\/5 {
+  width: 80%;
+}
+
+.w-full {
+  width: 100%;
+}
+
+.max-w-3xl {
+  max-width: 48rem;
+}
+
+.max-w-lg {
+  max-width: 32rem;
+}
+
+.flex-1 {
+  flex: 1 1 0%;
+}
+
+.list-none {
+  list-style-type: none;
+}
+
+.flex-col {
+  flex-direction: column;
+}
+
+.items-center {
+  align-items: center;
+}
+
+.rounded {
+  border-radius: 0.25rem;
+}
+
+.rounded-lg {
+  border-radius: 0.5rem;
+}
+
+.rounded-md {
+  border-radius: 0.375rem;
+}
+
 .border {
   border-width: 1px;
+}
+
+.border-gray-300 {
+  --tw-border-opacity: 1;
+  border-color: rgb(209 213 219 / var(--tw-border-opacity));
+}
+
+.border-red-500 {
+  --tw-border-opacity: 1;
+  border-color: rgb(239 68 68 / var(--tw-border-opacity));
+}
+
+.bg-gray-200 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(229 231 235 / var(--tw-bg-opacity));
+}
+
+.bg-gray-700 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(55 65 81 / var(--tw-bg-opacity));
+}
+
+.bg-indigo-500 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(99 102 241 / var(--tw-bg-opacity));
+}
+
+.bg-white {
+  --tw-bg-opacity: 1;
+  background-color: rgb(255 255 255 / var(--tw-bg-opacity));
+}
+
+.bg-gradient-to-r {
+  background-image: linear-gradient(to right, var(--tw-gradient-stops));
+}
+
+.from-blue-800 {
+  --tw-gradient-from: #1e40af var(--tw-gradient-from-position);
+  --tw-gradient-to: rgb(30 64 175 / 0) var(--tw-gradient-to-position);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to);
+}
+
+.from-gray-900 {
+  --tw-gradient-from: #111827 var(--tw-gradient-from-position);
+  --tw-gradient-to: rgb(17 24 39 / 0) var(--tw-gradient-to-position);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to);
+}
+
+.via-blue-900 {
+  --tw-gradient-to: rgb(30 58 138 / 0)  var(--tw-gradient-to-position);
+  --tw-gradient-stops: var(--tw-gradient-from), #1e3a8a var(--tw-gradient-via-position), var(--tw-gradient-to);
+}
+
+.to-blue-800 {
+  --tw-gradient-to: #1e40af var(--tw-gradient-to-position);
+}
+
+.to-gray-900 {
+  --tw-gradient-to: #111827 var(--tw-gradient-to-position);
+}
+
+.object-contain {
+  object-fit: contain;
+}
+
+.p-2 {
+  padding: 0.5rem;
+}
+
+.p-6 {
+  padding: 1.5rem;
+}
+
+.px-2 {
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
 }
 
 .px-4 {
@@ -613,20 +785,222 @@ video {
   padding-right: 1rem;
 }
 
+.px-6 {
+  padding-left: 1.5rem;
+  padding-right: 1.5rem;
+}
+
+.py-1 {
+  padding-top: 0.25rem;
+  padding-bottom: 0.25rem;
+}
+
+.py-2 {
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+}
+
+.py-20 {
+  padding-top: 5rem;
+  padding-bottom: 5rem;
+}
+
+.py-4 {
+  padding-top: 1rem;
+  padding-bottom: 1rem;
+}
+
+.py-8 {
+  padding-top: 2rem;
+  padding-bottom: 2rem;
+}
+
+.text-left {
+  text-align: left;
+}
+
+.text-center {
+  text-align: center;
+}
+
+.text-justify {
+  text-align: justify;
+}
+
+.text-2xl {
+  font-size: 1.5rem;
+  line-height: 2rem;
+}
+
 .text-3xl {
   font-size: 1.875rem;
   line-height: 2.25rem;
 }
 
-.text-xl {
-  font-size: 1.25rem;
+.text-5xl {
+  font-size: 3rem;
+  line-height: 1;
+}
+
+.text-lg {
+  font-size: 1.125rem;
   line-height: 1.75rem;
+}
+
+.text-sm {
+  font-size: 0.875rem;
+  line-height: 1.25rem;
 }
 
 .font-bold {
   font-weight: 700;
 }
 
+.font-semibold {
+  font-weight: 600;
+}
+
+.text-blue-500 {
+  --tw-text-opacity: 1;
+  color: rgb(59 130 246 / var(--tw-text-opacity));
+}
+
+.text-gray-600 {
+  --tw-text-opacity: 1;
+  color: rgb(75 85 99 / var(--tw-text-opacity));
+}
+
+.text-gray-700 {
+  --tw-text-opacity: 1;
+  color: rgb(55 65 81 / var(--tw-text-opacity));
+}
+
+.text-white {
+  --tw-text-opacity: 1;
+  color: rgb(255 255 255 / var(--tw-text-opacity));
+}
+
+.underline {
+  text-decoration-line: underline;
+}
+
+.shadow-md {
+  --tw-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
+  --tw-shadow-colored: 0 4px 6px -1px var(--tw-shadow-color), 0 2px 4px -2px var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.shadow-sm {
+  --tw-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+  --tw-shadow-colored: 0 1px 2px 0 var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
 .filter {
   filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow);
+}
+
+.hover\:bg-gray-300:hover {
+  --tw-bg-opacity: 1;
+  background-color: rgb(209 213 219 / var(--tw-bg-opacity));
+}
+
+.hover\:bg-indigo-600:hover {
+  --tw-bg-opacity: 1;
+  background-color: rgb(79 70 229 / var(--tw-bg-opacity));
+}
+
+.hover\:text-gray-400:hover {
+  --tw-text-opacity: 1;
+  color: rgb(156 163 175 / var(--tw-text-opacity));
+}
+
+.focus\:border-indigo-500:focus {
+  --tw-border-opacity: 1;
+  border-color: rgb(99 102 241 / var(--tw-border-opacity));
+}
+
+.focus\:bg-indigo-600:focus {
+  --tw-bg-opacity: 1;
+  background-color: rgb(79 70 229 / var(--tw-bg-opacity));
+}
+
+.focus\:outline-none:focus {
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+}
+
+.focus\:ring:focus {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(3px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+}
+
+.focus\:ring-indigo-200:focus {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgb(199 210 254 / var(--tw-ring-opacity));
+}
+
+.focus\:ring-opacity-50:focus {
+  --tw-ring-opacity: 0.5;
+}
+
+@media (min-width: 640px) {
+  .sm\:px-6 {
+    padding-left: 1.5rem;
+    padding-right: 1.5rem;
+  }
+}
+
+@media (min-width: 768px) {
+  .md\:mb-0 {
+    margin-bottom: 0px;
+  }
+
+  .md\:ml-5 {
+    margin-left: 1.25rem;
+  }
+
+  .md\:mr-5 {
+    margin-right: 1.25rem;
+  }
+
+  .md\:mt-0 {
+    margin-top: 0px;
+  }
+
+  .md\:flex {
+    display: flex;
+  }
+
+  .md\:w-1\/2 {
+    width: 50%;
+  }
+
+  .md\:max-w-xs {
+    max-width: 20rem;
+  }
+
+  .md\:flex-row {
+    flex-direction: row;
+  }
+
+  .md\:justify-between {
+    justify-content: space-between;
+  }
+
+  .md\:pl-6 {
+    padding-left: 1.5rem;
+  }
+
+  .md\:pr-6 {
+    padding-right: 1.5rem;
+  }
+}
+
+@media (min-width: 1024px) {
+  .lg\:px-8 {
+    padding-left: 2rem;
+    padding-right: 2rem;
+  }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -3,6 +3,8 @@ body {
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
     'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
     sans-serif;
+  /* Soft background for a cleaner look */
+  background-color: #f8fafc;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }

--- a/src/views/Contacto.js
+++ b/src/views/Contacto.js
@@ -63,7 +63,7 @@ const Contacto = () => {
     };
 
     return (
-        <div className="bg-gray-200 py-8 px-4 sm:px-6 lg:px-8 max-w-3xl mx-auto rounded-lg">
+        <div className="bg-white shadow-md py-8 px-4 sm:px-6 lg:px-8 max-w-3xl mx-auto rounded-lg">
             <h1 className="text-2xl font-semibold mb-4">{t("contacto")}</h1>
             <form onSubmit={handleSubmit}>
                 <div className="mb-4">

--- a/src/views/Curriculum.js
+++ b/src/views/Curriculum.js
@@ -40,7 +40,7 @@ const Curriculum = () =>{
     };
 
     return (
-        <div style={{ backgroundColor: "#f2f2f2", padding: "20px", borderRadius: "8px", maxWidth: "450px", margin: "0 auto",textAlign:"left" }}>
+        <div className="bg-white shadow-md p-6 rounded max-w-lg mx-auto text-left">
             <h1 >{t("curriculum")}</h1>
             <form onSubmit={handleSubmit}>
                 <p>

--- a/src/views/Error.js
+++ b/src/views/Error.js
@@ -1,8 +1,9 @@
 import React from "react";
 const Error = () =>{
     return (
-        <div>
-            <h1>Esta es la pagina de Error</h1>
+        <div className="container mx-auto px-4 py-20 text-center">
+            <h1 className="text-3xl font-bold mb-4">Esta es la pagina de Error</h1>
+            <p className="text-gray-600">Lo sentimos, la página que buscas no existe.</p>
         </div>
     )
 }

--- a/src/views/Inicio.js
+++ b/src/views/Inicio.js
@@ -23,7 +23,7 @@ const Inicio = () => {
     };
 
     return (
-        <div className="container mx-auto px-4">
+        <div className="container mx-auto px-4 py-8 bg-white shadow-md rounded">
             <h1 className="text-5xl font-bold mb-6">{t("inicio")}</h1>
             <p className="text-lg">{t("pInicio")}</p>
 

--- a/src/views/Portfolio.js
+++ b/src/views/Portfolio.js
@@ -23,44 +23,43 @@ const Portfolio = () =>{
     };
 
     return (
-        <div>
-            <h1>{t("proyectos")}</h1>
+        <div className="container mx-auto px-4 py-8">
+            <h1 className="text-2xl font-bold mb-6">{t("proyectos")}</h1>
 
             {/* Sección 1 */}
-            <div style={{ display: "flex", alignItems: "center" }}>
-                <div style={{ flex: 1 }}>
-                    <img src={calmar} alt="Foto 1" style={{ width: "100%" , marginLeft: "20px" }}/>
+            <div className="md:flex items-center mb-8">
+                <div className="md:w-1/2">
+                    <img src={calmar} alt="Foto 1" className="rounded shadow-md md:ml-5 w-full" />
                 </div>
-                <div style={{ flex: 1, padding: "0 20px" }}>
-                    <p style={{padding: "0 20px" }}>{t("textoImagen1")}
-                    </p>
+                <div className="md:w-1/2 md:pl-6 mt-4 md:mt-0">
+                    <p className="text-justify">{t("textoImagen1")}</p>
                 </div>
             </div>
 
             {/* Sección 2 */}
-            <div style={{ display: "flex", alignItems: "center" }}>
-                <div style={{ flex: 1, padding: "0 20px" }}>
-                    <p style={{padding: "0 20px" }}>{t("textoImagen2")}</p>
+            <div className="md:flex items-center mb-8">
+                <div className="md:w-1/2 md:pr-6 mb-4 md:mb-0">
+                    <p className="text-justify">{t("textoImagen2")}</p>
                 </div>
-                <div style={{ flex: 1 }}>
-                    <img src={rackcanarias} alt="Foto 2" style={{ width: "100%", marginRight:"20px" }} />
+                <div className="md:w-1/2">
+                    <img src={rackcanarias} alt="Foto 2" className="rounded shadow-md md:mr-5 w-full" />
                 </div>
             </div>
 
             {/* Sección 3 */}
-            <div style={{ display: "flex", alignItems: "center" }}>
-                <div style={{ flex: 1, padding: "0 20px" }}>
-                    <img src={kiwoko } alt="Foto 3" style={{ width: "100%" }} />
+            <div className="md:flex items-center mb-8">
+                <div className="md:w-1/2">
+                    <img src={kiwoko} alt="Foto 3" className="rounded shadow-md md:ml-5 w-full" />
                 </div>
-                <div style={{ flex: 1 }}>
-                    <p style={{padding: "0 20px" }}>{t("textoImagen3")}</p>
+                <div className="md:w-1/2 md:pl-6 mt-4 md:mt-0">
+                    <p className="text-justify">{t("textoImagen3")}</p>
                 </div>
             </div>
 
             {/* Selector de idioma */}
-            <div>
+            <div className="mt-6">
                 {LANGUAGES.map((language) => (
-                    <button key={language.code} onClick={() => changeLanguage(language.code)}>
+                    <button key={language.code} onClick={() => changeLanguage(language.code)} className="mr-2 px-4 py-2 bg-gray-200 rounded-md hover:bg-gray-300">
                         {language.name}
                     </button>
                 ))}

--- a/src/views/Proyectos.js
+++ b/src/views/Proyectos.js
@@ -43,7 +43,7 @@ const Proyectos = () => {
     };
 
     return (
-        <div className="text-center">
+        <div className="container mx-auto px-4 py-8 text-center bg-white shadow-md rounded">
             <h1 className="text-2xl font-bold">{t("proyectos")}</h1>
             <label htmlFor="searchInput" className="block">{t("buscadorProyectos")}</label>
             <input

--- a/src/views/Servicios.js
+++ b/src/views/Servicios.js
@@ -8,18 +8,28 @@ import react from "../imagen/react-logo.jpg";
 const Servicios = () => {
     const { t } = useTranslation();
     return (
-        <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '20px' }}>
-            <div style={{ flex: 1, textAlign: 'center', maxWidth: '30%', height: '100%' }}>
-                <img src={html} alt="HTML y CSS" style={{ maxWidth: '100%', maxHeight: '100%' }} />
-                <p style={{ fontWeight: 'bold', fontSize: '16px', margin: "20px" }}>{t("descripcion1")}</p>
+        <div className="container mx-auto px-4 py-8">
+            <h1 className="text-2xl font-bold mb-6 text-center">{t("h1servicios")}</h1>
+            <div className="flex flex-col md:flex-row md:justify-between">
+                <div className="flex-1 text-center md:max-w-xs mb-8 md:mb-0">
+                    <img src={html} alt="HTML y CSS" className="mx-auto h-32 object-contain" />
+                    <p className="font-bold text-sm mt-4">{t("descripcion1")}</p>
+                </div>
+                <div className="flex-1 text-center md:max-w-xs mb-8 md:mb-0">
+                    <img src={java} alt="Java" className="mx-auto h-32 object-contain" />
+                    <p className="font-bold text-sm mt-4">{t("descripcion2")}</p>
+                </div>
+                <div className="flex-1 text-center md:max-w-xs">
+                    <img src={react} alt="React" className="mx-auto h-32 object-contain" />
+                    <p className="font-bold text-sm mt-4">{t("descripcion3")}</p>
+                </div>
             </div>
-            <div style={{ flex: 1, textAlign: 'center', maxWidth: '30%', height: '100%' }}>
-                <img src={java} alt="Java" style={{ maxWidth: '100%', maxHeight: '100%' }} />
-                <p style={{ fontWeight: 'bold', fontSize: '16px', margin: "20px" }}>{t("descripcion2")}</p>
-            </div>
-            <div style={{ flex: 1, textAlign: 'center', maxWidth: '30%', height: '100%' }}>
-                <img src={react} alt="React" style={{ maxWidth: '100%', maxHeight: '100%' }} />
-                <p style={{ fontWeight: 'bold', fontSize: '16px', margin: "20px" }}>{t("descripcion3")}</p>
+            <div className="mt-6 text-center">
+                {LANGUAGES.map((language) => (
+                    <button key={language.code} onClick={() => i18n.changeLanguage(language.code)} className="mr-2 px-4 py-2 bg-gray-200 rounded-md hover:bg-gray-300">
+                        {language.name}
+                    </button>
+                ))}
             </div>
         </div>
     )

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,8 +2,12 @@
 module.exports = {
   content: ["./src/**/*.{js,jsx,ts,tsx}"],
   theme: {
-  extend: {},
+    extend: {
+      fontFamily: {
+        sans: ["Segoe UI", "Helvetica", "Arial", "sans-serif"],
+      },
+    },
   },
   plugins: [],
-  }
+};
   


### PR DESCRIPTION
## Summary
- use gradient backgrounds for header and footer
- brighten page backgrounds and add container styles
- refactor views to use Tailwind styling
- tweak default font via Tailwind config

## Testing
- `npx tailwindcss -i ./src/css/tailwind.css -o ./src/css/styles.css`
- `npm test --silent` *(fails: react-scripts permission issues)*

------
https://chatgpt.com/codex/tasks/task_b_683ffc0e7488832795b9ecba666d2f1a